### PR TITLE
add waitForEvent' that has the same signature as waitForEvent and rea…

### DIFF
--- a/src/Control/Monad/Loops/STM.hs
+++ b/src/Control/Monad/Loops/STM.hs
@@ -39,3 +39,15 @@ waitForJust m = fmap fromJust (waitFor isJust m)
 -- Returns the winner.
 waitForEvent :: (a -> Bool) -> TChan a -> STM a
 waitForEvent p events = waitFor p (readTChan events)
+
+-- |'waitForEvent' a value satisfying a condition to come out of a
+-- 'Control.Concurrent.STM.TChan', reading and discarding (really) everything else.
+-- Returns the winner.
+waitForEvent' :: (a -> Bool) -> TChan a -> STM a
+waitForEvent' p chan = checkEvent
+    where
+      checkEvent = do
+        event <- readTChan chan
+        if p event
+            then return event
+            else checkEvent


### PR DESCRIPTION
…lly discard events that were obtained prior to matching the predicate

This snippet shows the issue with current waitForEvent:
testWaitForEvent1::IO ()
testWaitForEvent1 = do
  chan <- newTChanIO

  _ <- forkIO $  atomically $
                       writeTChan chan (0::Int) >>
                       writeTChan chan (1::Int)

-- if I use >= 0 as predicate, then it does work
  res <- atomically $ waitForEvent (>0) chan
  print res
